### PR TITLE
Revert "Create The Initial State Add CurrencyListInitial state to currency list feature"

### DIFF
--- a/lib/data/repositories/currency_rates_repository.dart
+++ b/lib/data/repositories/currency_rates_repository.dart
@@ -7,11 +7,11 @@ import '../services/currency_api_service.dart';
 
 part 'currency_rates_repository.g.dart';
 
-abstract interface class CurrencyRatesRepository{
+abstract interface class CurrencyRatesRepository {
   Future<Result<CurrencyRates>> load();
 }
 
-class RemoteCurrencyRatesRepository implements CurrencyRatesRepository{
+class RemoteCurrencyRatesRepository implements CurrencyRatesRepository {
   final CurrencyApiService apiService;
 
   const RemoteCurrencyRatesRepository(this.apiService);

--- a/lib/ui/currency_list/view_model/currency_list_state.dart
+++ b/lib/ui/currency_list/view_model/currency_list_state.dart
@@ -4,10 +4,6 @@ sealed class CurrencyListState {
   const CurrencyListState();
 }
 
-class CurrencyListInitial extends CurrencyListState {
-  const CurrencyListInitial();
-}
-
 class CurrencyListLoading extends CurrencyListState {
   const CurrencyListLoading();
 }

--- a/lib/ui/currency_list/view_model/currency_list_viewmodel.dart
+++ b/lib/ui/currency_list/view_model/currency_list_viewmodel.dart
@@ -15,11 +15,10 @@ class CurrencyListViewModel {
   CurrencyListViewModel(this._repository);
 
   final currencies = ValueNotifier<CurrencyListState>(
-    const CurrencyListInitial(),
+    const CurrencyListLoading(),
   );
 
   Future<void> load() async {
-    currencies.value = CurrencyListLoading();
     final result = await _repository.load();
 
     switch (result) {

--- a/lib/ui/currency_list/widgets/currency_list_screen.dart
+++ b/lib/ui/currency_list/widgets/currency_list_screen.dart
@@ -29,7 +29,6 @@ class _CurrencyListScreenState extends ConsumerState<CurrencyListScreen> {
           valueListenable: viewModel.currencies,
           builder: (context, state, child) {
             switch (state) {
-              case CurrencyListInitial():
               case CurrencyListLoading():
                 return const CircularProgressIndicator();
               case CurrencyListLoaded():


### PR DESCRIPTION
Reverts tilucasoli/currency_app#1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Code Cleanup**
	- Removed `CurrencyListInitial` state from currency list state management
	- Simplified view model's initial state handling
	- Removed `CurrencyListInitial` case from widget's state rendering

- **Refactor**
	- Streamlined state management for currency list functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->